### PR TITLE
Update Docker publish workflow to use secrets for credentials

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -58,7 +58,7 @@ jobs:
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
+          username: $(( secrets.GHCR_USERNAME )) # default value: ${{ github.actor }}
           password: ${{ secrets.GHRC_TOKEN }} # default value: ${{ secrets.GITHUB_TOKEN }}
 
       # Extract metadata (tags, labels) for Docker


### PR DESCRIPTION
Modify the Docker publish workflow to utilize secrets for the username and token, enhancing security during the publishing process.