### PR TITLE
Refactor Docker publish workflow for authentication

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -58,8 +58,8 @@ jobs:
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:
           registry: ${{ env.REGISTRY }}
-          username: $(( secrets.GHCR_USERNAME )) # default value: ${{ github.actor }}
-          password: ${{ secrets.GHRC_TOKEN }} # default value: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action


### PR DESCRIPTION
Update the Docker publish workflow to utilize `github.actor` for the username and `GITHUB_TOKEN` for the password, enhancing security and simplifying the authentication process.